### PR TITLE
Fix variable length integer not being written if the value is 0.

### DIFF
--- a/ndspy/soundSequence.py
+++ b/ndspy/soundSequence.py
@@ -293,9 +293,11 @@ def _writeVariableLengthInt(x):
 
     ret = []
 
-    while x:
+    while True:
         value, x = x & 0x7F, x >> 7
         ret.append(value)
+        if x == 0:
+            break
 
     ret.reverse()
 


### PR DESCRIPTION
This fixes `_writeVariableLengthInt(x)` not writing anything when `x` equals 0. The correct behavior is that a `0x00` byte is written.