### PR TITLE
Add some type annotations, drop support for Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This section will try to answer some questions you may have.
 Installation
 ------------
 
-ndspy requires Python 3.6 or newer to run. CPython (the reference
+ndspy requires Python 3.7 or newer to run. CPython (the reference
 implementation of Python) and PyPy are both supported. Python 2, though, is not
 supported at all.
 

--- a/ndspy/bmg.py
+++ b/ndspy/bmg.py
@@ -17,7 +17,7 @@
 """
 Support for BMG files.
 """
-
+from __future__ import annotations
 
 import struct
 
@@ -36,12 +36,12 @@ class BMG:
     A class representing a BMG file.
     """
 
-    def __init__(self, data=None, *, id=0):
+    def __init__(self, data: bytes | None = None, *, id=0):
 
-        self.messages = []
-        self.instructions = []
-        self.labels = []
-        self.scripts = []
+        self.messages: list[Message] = []
+        self.instructions: list[bytes] = []
+        self.labels: list[tuple[int, int]] = []
+        self.scripts: list[tuple[int, int]] = []
 
         self.id = id
 
@@ -62,7 +62,7 @@ class BMG:
         return self.encoding
 
 
-    def _initFromData(self, data):
+    def _initFromData(self, data: bytes):
         if data[:8] != b'MESGbmg1':
             raise ValueError('Not a BMG file.')
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/RoadrunnerWMC/ndspy',
     packages=setuptools.find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'ndspy_codeCompression = ndspy.codeCompression:main',
@@ -21,7 +21,6 @@ setuptools.setup(
         ],
     },
     classifiers=[
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This PR adds a few basic type annotations to the `bmg` module. The main motivation behind this is to improve developer experience when using `ndspy` in an IDE. For example, consider the following snippet of code:

```python
from ndspy import bmg

bmg_file = bmg.BMG(<some data>)

for message in bmg_file.messages:
  print(message.stringParts)
```

The `BMG.messages` instance variable is untyped in `ndspy`, so an IDE wouldn't be able to offer a code suggestion for `.stringParts`, and the user would have to consult the docs for the exact attributes of `message`.

@RoadrunnerWMC are you open to this change/more changes like it? I've been adding some type annotations like these to my local copy of `ndspy` to aid my own development, but if they can be of use more generally then I'm happy to upstream them. 

One additional note - I also dropped support for Python 3.6 in this PR to enable usage of the `from __future__ import annotations` import, which allows usage of more modern typing syntax like `list[T]`, `tuple[T, T]`, `X | Y` etc. for Python 3.7+ over `typing.List[T]`, `typing.Tuple[T, T]`, `typing.Union[X, Y]`, etc. I figured this might be acceptable since 3.6 (and 3.7 in fact) are EOL. But if you'd prefer not to do that, and do want to accept this PR, let me know and I can change it to the 3.6-compatible types.