### PR TITLE
Fix issue with tests, add GitHub workflow for running test suite as CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    name: Run tests [${{ matrix.os }} / Python ${{ matrix.python-version }}]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+
+      - name: Install test dependencies
+        run: pip install .[test]
+
+      - name: Run tests
+        run: pytest tests/

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,7 @@ setuptools.setup(
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Operating System :: OS Independent',
     ],
+    extras_require={
+        'test': ['pytest'],
+    },
 )

--- a/tests/test_bmg.py
+++ b/tests/test_bmg.py
@@ -26,7 +26,7 @@ import ndspy.bmg
 import pytest
 
 
-FILES_PATH = pathlib.Path('../test_files/bmg')
+FILES_PATH = pathlib.Path(__file__).parents[1] / 'test_files' / 'bmg'
 
 
 # Some example values to use in various contexts


### PR DESCRIPTION
This PR fixes a minor issue I noticed when I tried running the unit tests locally to sanity check my type annotation PRs. Currently, the pytest suite assumes the user's working directory is the `tests` subdirectory of the repo, and uses that to locate the test data with `pathlib`. This change makes it so the test suite can be run from any working directory by deriving the location of the test data files with `pathlib` and the `__file__` variable.

I've also added two additional items that I thought might make future external contributions easier - 
(1) an `extras_require` target for test dependencies (in this case, only `pytest` is required)
(2) a GitHub Actions workflow that runs the test suite across every supported OS and Python version; this will run on every pull request and on every commit to `master` .