### PR TITLE
Add `py.typed` file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/RoadrunnerWMC/ndspy',
     packages=setuptools.find_packages(),
+    package_data={
+        'ndspy': ['py.typed'],
+    },
     python_requires='>=3.7',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This adds a `py.typed` file and bundles it in the `ndspy` package. This enables downstream users to type-check their usage of `ndspy` ([PEP 561](https://peps.python.org/pep-0561/#packaging-type-information)).