### PR TITLE
Align final ROM size to multiple of 0x400

### DIFF
--- a/ndspy/rom.py
+++ b/ndspy/rom.py
@@ -451,6 +451,10 @@ class NintendoDSRom:
         # We need to do this for compatibility with NSMBe
         struct.pack_into('<I', data, 0x1000, rsaSignatureOffset)
 
+        # The BizHawk MelonDS core, and maybe also other emulators,
+        # fails if the ROM size isn't a multiple of 0x400
+        align(0x400)
+
         # Now that we know how large the ROM data is, we can update the
         # device capacity value
         if updateDeviceCapacity:
@@ -541,7 +545,6 @@ class NintendoDSRom:
         assert len(self.pad16C) == 0x94, f'(Save) Wrong pad16C length: {hex(len(self.pad16C))}'
         writeRaw(self.pad16C)
         assert headerOffset == 0x200, f'(Save) Header offset check at 0x200: {hex(headerOffset)}'
-        align(0x400)
 
         return bytes(data)
 

--- a/ndspy/rom.py
+++ b/ndspy/rom.py
@@ -541,6 +541,7 @@ class NintendoDSRom:
         assert len(self.pad16C) == 0x94, f'(Save) Wrong pad16C length: {hex(len(self.pad16C))}'
         writeRaw(self.pad16C)
         assert headerOffset == 0x200, f'(Save) Header offset check at 0x200: {hex(headerOffset)}'
+        align(0x400)
 
         return bytes(data)
 


### PR DESCRIPTION
Emulators such as the BizHawk MelonDS core expect the ROM size to be a multiple of 1024/0x400.