### PR TITLE
Fix incorrect type annotations

### DIFF
--- a/docs/source/api/code.rst
+++ b/docs/source/api/code.rst
@@ -175,7 +175,7 @@ The ``ndspy.code`` module can be used to load and save executable code files:
 
         The code data for this section.
 
-        :type: :py:class:`bytes`
+        :type: :py:class:`bytearray`
 
     .. py:attribute:: implicit
 
@@ -243,7 +243,7 @@ The ``ndspy.code`` module can be used to load and save executable code files:
 
     .. py:attribute:: data
 
-        The :py:class:`bytes` object containing the decompressed code for this
+        The :py:class:`bytearray` object containing the decompressed code for this
         overlay.
 
     .. py:attribute:: compressed

--- a/ndspy/code.py
+++ b/ndspy/code.py
@@ -55,7 +55,7 @@ class MainCodeFile:
         section.
         """
 
-        data: bytes
+        data: bytearray
         ramAddress: int
         bssSize: int
         # There's an implicit first section in the file, which is not
@@ -471,4 +471,4 @@ def saveOverlayTable(table: dict[int, Overlay]) -> bytes:
 
         ovt.extend(struct.pack('<8I', *values))
 
-    return ovt
+    return bytes(ovt)

--- a/ndspy/code.py
+++ b/ndspy/code.py
@@ -320,7 +320,7 @@ class Overlay:
     An ARM7 or ARM9 code overlay.
     """
 
-    data: bytes
+    data: bytearray
     ramAddress: int
     ramSize: int
     bssSize: int

--- a/ndspy/codeCompression.py
+++ b/ndspy/codeCompression.py
@@ -56,7 +56,7 @@ def _detectAppendedData(data: bytes) -> int | None:
     return None
 
 
-def decompress(data: bytes) -> bytearray:
+def decompress(data: bytes) -> bytes:
     """
     Decompress data that was compressed using code compression. This is
     the inverse of compress().
@@ -210,7 +210,7 @@ def decompress(data: bytes) -> bytearray:
             decompData[-1 - currentOutSize] = next
             currentOutSize += 1
 
-    return passthroughData + decompData + appendedData
+    return bytes(passthroughData + decompData + appendedData)
 
 
 def decompressFromFile(filePath: str | os.PathLike) -> bytes:

--- a/ndspy/codeCompression.py
+++ b/ndspy/codeCompression.py
@@ -56,7 +56,7 @@ def _detectAppendedData(data: bytes) -> int | None:
     return None
 
 
-def decompress(data: bytes) -> bytes:
+def decompress(data: bytes) -> bytearray:
     """
     Decompress data that was compressed using code compression. This is
     the inverse of compress().


### PR DESCRIPTION
It seems some of the type annotations I added in #16 and #18 were incorrect. I discovered this after upgrading my project to use ndspy 4.2.0, and it started failing type checking ([PR](https://github.com/phst-randomizer/ph-randomizer/pull/464), [failed mypy CI run](https://github.com/phst-randomizer/ph-randomizer/actions/runs/10968117509/job/30459003309?pr=464)).

I confirmed the `decompress` return type is `bytearray` by calling it on a compressed ARM9 `bytes` object and calling `type()` on it. The type of `Overlay.data` is easily confirmed as a `bytearray` by looking at the `__init__` constructor for that class.