### PR TITLE
Update LZ Compression to match Nintendo

### DIFF
--- a/ndspy/_lzCommon.py
+++ b/ndspy/_lzCommon.py
@@ -119,19 +119,18 @@ def compress(data, posSubtract, maxMatchDiff, maxMatchLen, zerosAtEnd,
                 ignorableDataAmount = 0
                 ignorableCompressedAmount = 0
                 bestSavingsSoFar = savingsNow
-                if (savingsNow not in ignoreDict):
+                if savingsNow not in ignoreDict:
                     ignoreDict[savingsNow] = (current, len(result))
  
         result[blockFlagsOffset] = blockFlags
 
-    # Original BLZ Return
+    # Original BLZ return
     # return bytes(result), ignorableDataAmount, ignorableCompressedAmount
 
     finalSavings = current - len(result)
-    i = 0
-    if (finalSavings < bestSavingsSoFar):
+    if finalSavings < bestSavingsSoFar:
         finalSavings += 1
-        while (finalSavings not in ignoreDict):
+        while finalSavings not in ignoreDict:
             finalSavings += 1
         ignD = current - ignoreDict[finalSavings][0]
         ignC = len(result) - ignoreDict[finalSavings][1]

--- a/ndspy/_lzCommon.py
+++ b/ndspy/_lzCommon.py
@@ -74,6 +74,7 @@ def compress(data, posSubtract, maxMatchDiff, maxMatchLen, zerosAtEnd,
 
     ignorableDataAmount = 0
     ignorableCompressedAmount = 0
+    ignoreDict = {0: (current, len(result))}
 
     bestSavingsSoFar = 0
 
@@ -118,7 +119,24 @@ def compress(data, posSubtract, maxMatchDiff, maxMatchLen, zerosAtEnd,
                 ignorableDataAmount = 0
                 ignorableCompressedAmount = 0
                 bestSavingsSoFar = savingsNow
-
+                if (savingsNow not in ignoreDict):
+                    ignoreDict[savingsNow] = (current, len(result))
+ 
         result[blockFlagsOffset] = blockFlags
 
-    return bytes(result), ignorableDataAmount, ignorableCompressedAmount
+    # Original BLZ Return
+    # return bytes(result), ignorableDataAmount, ignorableCompressedAmount
+
+    finalSavings = current - len(result)
+    i = 0
+    if (finalSavings < bestSavingsSoFar):
+        finalSavings += 1
+        while (finalSavings not in ignoreDict):
+            finalSavings += 1
+        ignD = current - ignoreDict[finalSavings][0]
+        ignC = len(result) - ignoreDict[finalSavings][1]
+        return bytes(result), ignD, ignC
+    else:
+        return bytes(result), 0, 0
+    
+   


### PR DESCRIPTION
Updated _lzCommon.py with new Ignore Boundary calculations. Left old calculations intact, and old return commented.

The way BLZ calculates ignore boundaries is different than how Nintendo, or at least Game Freak, calculate their ignore boundaries for LZ Compression. BLZ produces perfectly valid compressions, and very occasionally even better compressions. However, if our priority is files for editing Nintendo ROMs, valid files are not always enough, we are looking for valid files that match the originals as closely as possible. This fix makes the lzCommon compress function produce files that exactly match the original targets, at least in all the cases I tested.

Tested on:
* English Pokemon Heartgold ARM9
* English Pokemon Heartgold all Overlays
* English Pokemon Black ARM9
* English Pokemon Black all Overlays.

Old Algorithm calculated IgnoreBoundary to match the most recent position where savings improved. This produced:
* Mostly identical compressions to the ones found on the ROMS I checked
* Sometimes different compressions of the same size
* Occasionally better compressions of a smaller size

From my reverse engineering, my guess is that Nintendo BLZ compression saved an IgnoreBoundary each time savings improved, and then at the end, returned the IgnoreBoundary associated with the savings value closest to the final calculated savings. 

Two quick examples to illustrate:

Heartgold ARM9 Original: 762,644 Bytes, boundary at 0x41BA
Re-Compressed by NDSPY/BLZ: 762,632 Bytes, Boundary 0x416D
Re-Compressed by NDSPY with this fix: 762,644 Bytes, boundary at 0x41BA

Heartgold Overlay_0004 Original: 11,824 Bytes, Boundary at 0x9
Re-Compressed by NDSPY/BLZ: 11,824 Bytes, Boundary at 0x5
Re-Compressed by NDSPY/BLZ with this fix: 11,824 Bytes, Boundary at 0x9