### PR TITLE
Improve __repr__ for `NintendoDSRom`

### DIFF
--- a/ndspy/rom.py
+++ b/ndspy/rom.py
@@ -631,8 +631,4 @@ class NintendoDSRom:
 
 
     def __repr__(self) -> str:
-        try:
-            data = _common.shortBytesRepr(self.save())
-        except Exception:
-            data = '...'
-        return f'{type(self).__name__}({data})'
+        return f"NintendoDsRom({self.name!r})"


### PR DESCRIPTION
The current `__repr__` function isn't very useful and causes debugging to be a nightmare. Each step ends up being very slow and annoying to use. This PR changes that to not have to save on every step, thus improving debugging.

![image](https://github.com/user-attachments/assets/126c0b38-4b6a-4305-a396-13c6ee8c41e5)
