### PR TITLE
Optimize the search for byte sequences

### DIFF
--- a/ndspy/_lzCommon.py
+++ b/ndspy/_lzCommon.py
@@ -53,9 +53,9 @@ def compress(data, posSubtract, maxMatchDiff, maxMatchLen, zerosAtEnd,
             matchLen = (lower + upper) // 2
             match = data[pos : pos + matchLen]
             if searchReverse:
-                matchPos = data.rfind(match, start, pos)
+                matchPos = data.rfind(match, start, pos + matchLen - 1)
             else:
-                matchPos = data.find(match, start, pos)
+                matchPos = data.find(match, start, pos + matchLen - 1)
 
             if matchPos == -1:
                 # No such match -- any matches will be smaller than this


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/17018e54-eb15-4367-8baa-b6f17e299c3b)

In certain cases, the end position of a repeated byte sequence may extend beyond the start position of the original data. [Wikipedia](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77):

> It is not only acceptable but frequently useful to allow length-distance pairs to specify a length that actually exceeds the distance. As a copy command, this is puzzling: "Go back four characters and copy ten characters from that position into the current position". How can ten characters be copied over when only four of them are actually in the buffer? Tackling one byte at a time, there is no problem serving this request, because as a byte is copied over, it may be fed again as input to the copy command. When the copy-from position makes it to the initial destination position, it is consequently fed data that was pasted from the beginning of the copy-from position. The operation is thus equivalent to the statement "copy the data you were given and repetitively paste it until it fits". As this type of pair repeats a single copy of data multiple times, it can be used to incorporate a flexible and easy form of [run-length encoding](https://en.wikipedia.org/wiki/Run-length_encoding).

For example:

``` python
import ndspy._lzCommon

uncompressed = bytes.fromhex("00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00")
compressed_1 = ndspy._lzCommon.compress(uncompressed, 1, 0x1000, 18, False, False)[0]
print(len(compressed_1))
# 10

print(compressed_1.hex(" "))
# 1c 00 00 00 00 02 30 05 40 0b
```

The data length obtained by the original compression method is 10 bytes. However, after modifying the search method, the compressed data length can be reduced to 4 bytes:

``` python
compressed_2 = compressCommon(uncompressed, 1, 0x1000, 18, False, False)[0]
print(len(compressed_2))
# 4

print(compressed_2.hex(" "))
# 40 00 f0 00
```